### PR TITLE
Precomplier flags for gstreamer versions that don't have gst_pipeline…

### DIFF
--- a/Pipeline.cpp
+++ b/Pipeline.cpp
@@ -45,7 +45,10 @@ void Pipeline::Init(Nan::ADDON_REGISTER_FUNCTION_ARGS_TYPE exports) {
 			
 	Nan::SetAccessor(proto, Nan::New("auto-flush-bus").ToLocalChecked(), GetAutoFlushBus, SetAutoFlushBus);
 	Nan::SetAccessor(proto, Nan::New("delay").ToLocalChecked(), GetDelay, SetDelay);
+	
+	#if GST_CHECK_VERSION(1,11,1)
 	Nan::SetAccessor(proto, Nan::New("latency").ToLocalChecked(), GetLatency, SetLatency);
+	#endif 
 	
 	constructor.Reset(ctor->GetFunction());
 	exports->Set(Nan::New("Pipeline").ToLocalChecked(), ctor->GetFunction());
@@ -210,6 +213,12 @@ NAN_SETTER(Pipeline::SetDelay) {
 		gst_pipeline_set_delay(obj->pipeline, DOUBLE_TO_NANOS(value->NumberValue()));
 	}
 }
+
+// GetLatency and SetLatency was added in version 1.11.1 check the installed
+// gst version to make sure this is supported
+// GST_CHECK_VERSION returns true if installed version is greater than
+// entered version
+#if GST_CHECK_VERSION(1,11,1)
 NAN_GETTER(Pipeline::GetLatency) {
 	Pipeline *obj = Nan::ObjectWrap::Unwrap<Pipeline>(info.This());
 	double secs = NANOS_TO_DOUBLE(gst_pipeline_get_latency(obj->pipeline));
@@ -221,3 +230,4 @@ NAN_SETTER(Pipeline::SetLatency) {
 		gst_pipeline_set_latency(obj->pipeline, DOUBLE_TO_NANOS(value->NumberValue()));
 	}
 }
+#endif

--- a/Pipeline.h
+++ b/Pipeline.h
@@ -42,8 +42,15 @@ class Pipeline : public Nan::ObjectWrap {
 		static NAN_SETTER(SetAutoFlushBus);
 		static NAN_GETTER(GetDelay);
 		static NAN_SETTER(SetDelay);
+		
+		// GetLatency and SetLatency was added in version 1.11.1 check the installed
+		// gst version to make sure this is supported
+		// GST_CHECK_VERSION returns true if installed version is greater than
+		// entered version
+		#if GST_CHECK_VERSION(1,11,1)
 		static NAN_GETTER(GetLatency);
 		static NAN_SETTER(SetLatency);
+		#endif
 		
 };
 


### PR DESCRIPTION
…_set_latency and gst_pipeline_get_latency added in gstreamer v.1.11.

[Link to gstreamer source the gstreamer V. 1.11 number came from](https://github.com/GStreamer/gstreamer/commit/abfcffde464753cbcb01a006183566c5b6f7ebe0)

This the precompiler flags as a separate pull request. If it's 1.6 instead I don't think I'd pull this into master. 