### PR TITLE
Add <pipeline>.sendEOS()

### DIFF
--- a/Pipeline.cpp
+++ b/Pipeline.cpp
@@ -39,6 +39,7 @@ void Pipeline::Init(Nan::ADDON_REGISTER_FUNCTION_ARGS_TYPE exports) {
 	Nan::SetPrototypeMethod(ctor, "play", Play);
 	Nan::SetPrototypeMethod(ctor, "pause", Pause);
 	Nan::SetPrototypeMethod(ctor, "stop", Stop);
+	Nan::SetPrototypeMethod(ctor, "sendEOS", SendEOS);
 	Nan::SetPrototypeMethod(ctor, "forceKeyUnit", ForceKeyUnit);
 	Nan::SetPrototypeMethod(ctor, "findChild", FindChild);
 	Nan::SetPrototypeMethod(ctor, "pollBus", PollBus);
@@ -78,6 +79,15 @@ void Pipeline::stop() {
 NAN_METHOD(Pipeline::Stop) {
 	Pipeline* obj = Nan::ObjectWrap::Unwrap<Pipeline>(info.This());
 	obj->stop();
+}
+
+void Pipeline::sendEOS() {
+	gst_element_send_event(GST_ELEMENT(pipeline), gst_event_new_eos());
+}
+
+NAN_METHOD(Pipeline::SendEOS) {
+	Pipeline* obj = Nan::ObjectWrap::Unwrap<Pipeline>(info.This());
+	obj->sendEOS();
 }
 
 void Pipeline::pause() {

--- a/Pipeline.h
+++ b/Pipeline.h
@@ -13,6 +13,7 @@ class Pipeline : public Nan::ObjectWrap {
 		void play();
 		void pause();
 		void stop();
+		void sendEOS();
 		void forceKeyUnit(GObject* sink, int cnt);
 		
 		GObject *findChild( const char *name );
@@ -31,6 +32,7 @@ class Pipeline : public Nan::ObjectWrap {
 		static NAN_METHOD(Play);
 		static NAN_METHOD(Pause);
 		static NAN_METHOD(Stop);
+		static NAN_METHOD(SendEOS);
 		static NAN_METHOD(ForceKeyUnit);
 		static NAN_METHOD(FindChild);
 


### PR DESCRIPTION
See issue raised.

This is a simple change to add the ability to send an EOS message to the pipeline. This is important as it allows the pipeline to sort itself out (such as flush buffers and close files) before a pipeline.stop(),

A more generic messaging capability would be better, but this is simple and meets the basic requirement.