### PR TITLE
Add appsrc push & caps functionality

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ find_package(PkgConfig)
 pkg_check_modules(gstreamer-1.0 gstreamer-app-1.0 gstreamer-video-1.0)
 
 include_directories(
-    /usr/local/include/node/
+    /usr/include/node
     ./node_modules/nan
     ${gstreamer-1.0_INCLUDE_DIRS}
     ${gstreamer-app-1.0_INCLUDE_DIRS}
@@ -14,5 +14,5 @@ include_directories(
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 
-set(SOURCE_FILES gstreamer.cpp)
+set(SOURCE_FILES gstreamer.cpp gstreamer.cpp GLibHelpers.cpp GObjectWrap.cpp Pipeline.cpp)
 add_executable(gstreamer-superficial ${SOURCE_FILES})

--- a/GObjectWrap.cpp
+++ b/GObjectWrap.cpp
@@ -49,6 +49,9 @@ Handle<Value> GObjectWrap::NewInstance( const Nan::FunctionCallbackInfo<Value>& 
 	
 	if(GST_IS_APP_SINK(obj))
 		Nan::SetMethod(instance, "pull", GstAppSinkPull);
+	if (GST_IS_APP_SRC(obj))
+		Nan::SetMethod(instance, "push", GstAppSrcPush);
+		Nan::SetMethod(instance, "setCapsFromString", GstAppSrcSetCapsFromString);
 	
 	info.GetReturnValue().Set(instance);
 	return scope.Escape(instance);
@@ -145,7 +148,7 @@ NAN_METHOD(GObjectWrap::GstAppSrcPush) {
             gst_buffer_fill(gst_buffer, 0, buffer, buffer_length);
 
             gst_app_src_push_buffer(GST_APP_SRC(obj->obj), gst_buffer);
-            gst_buffer_unref(gst_buffer);
+           // gst_buffer_unref(gst_buffer);
         }
         // TODO throw an error if arg is not a buffer object?
     }

--- a/GObjectWrap.h
+++ b/GObjectWrap.h
@@ -33,6 +33,8 @@ class GObjectWrap : public Nan::ObjectWrap {
 		static void _pulledBuffer( uv_work_t *req, int );
 		*/
 		static NAN_METHOD(GstAppSinkPull);
+        static NAN_METHOD(GstAppSrcPush);
+        static NAN_METHOD(GstAppSrcSetCapsFromString);
 };
 
 #endif


### PR DESCRIPTION
Working example shows a red 'movie':

```javascript

const gstreamer = require('./build/Release/gstreamer-superficial')

const pipeline = new gstreamer.Pipeline('appsrc name=mysource is-live=true ! ' +
    'videoconvert ! video/x-raw,format=I420,width=640,height=480 !' +
    'x264enc byte-stream=true key-int-max=30 pass=pass1 tune=zerolatency threads=2 ip-factor=2 speed-preset=veryfast intra-refresh=0 qp-max=43 !' +
    'video/x-h264,profile=constrained-baseline,stream-format=byte-stream,framerate=0/1 !' +
    'openh264dec !' +
    'autovideosink');

const appsrc = pipeline.findChild('mysource')
appsrc.setCapsFromString("video/x-raw,format=RGB,width=640,height=480,bpp=24,depth=24,framerate=0/1")
pipeline.play()


function frame() {
    appsrc.push(Buffer.alloc(640 * 480 * 3, "ff0000","hex"))
    setTimeout(frame, 33)
}

frame()
```