### PR TITLE
Included conversion for properties containing GstSamples

### DIFF
--- a/GLibHelpers.cpp
+++ b/GLibHelpers.cpp
@@ -73,6 +73,19 @@ Handle<Value> gvalue_to_v8(const GValue *gv) {
 	} else if(GST_VALUE_HOLDS_BUFFER(gv)) {
 		GstBuffer *buf = gst_value_get_buffer(gv);
 		return gstbuffer_to_v8(buf);
+	} else if(GST_VALUE_HOLDS_SAMPLE(gv)) {
+		GstSample *sample = gst_value_get_sample(gv);
+		Local<Object> caps = Nan::New<Object>();
+		GstCaps *gcaps = gst_sample_get_caps(sample);
+		if (gcaps) {
+			const GstStructure *structure = gst_caps_get_structure(gcaps,0);
+			if (structure) gst_structure_to_v8(caps, structure);
+		}
+
+		Local<Object> result = Nan::New<Object>();
+		result->Set(Nan::New("buf").ToLocalChecked(), gstsample_to_v8(sample));
+		result->Set(Nan::New("caps").ToLocalChecked(), caps);
+		return result;
 	}
 
 	//printf("Value is of unhandled type %s\n", G_VALUE_TYPE_NAME(gv));

--- a/examples/fakesink.js
+++ b/examples/fakesink.js
@@ -1,0 +1,13 @@
+#!/usr/bin/env node
+var gstreamer = require('..');
+
+var pipeline = new gstreamer.Pipeline('videotestsrc ! fakesink enable-last-sample=true name=sink');
+var appsink = pipeline.findChild('sink');
+
+pipeline.play();
+
+setTimeout( function() {
+  var sample = appsink['last-sample']; // Contains object like { buff: Buffer, caps: Object }
+  console.log('Got sample of: ', sample.buf.length, 'bytes. With caps: ', sample.caps);
+  pipeline.stop();
+}, 1000 );


### PR DESCRIPTION
I tried to follow the pattern {buf, caps} for the result like appsink element. This is useful in some elements like fakesink that can store last sample for you to recover it at any time.

Also included example in ```examples/fakesink.js```