### PR TITLE
Add setPad method

### DIFF
--- a/Pipeline.cpp
+++ b/Pipeline.cpp
@@ -42,6 +42,7 @@ void Pipeline::Init(Nan::ADDON_REGISTER_FUNCTION_ARGS_TYPE exports) {
 	Nan::SetPrototypeMethod(ctor, "sendEOS", SendEOS);
 	Nan::SetPrototypeMethod(ctor, "forceKeyUnit", ForceKeyUnit);
 	Nan::SetPrototypeMethod(ctor, "findChild", FindChild);
+	Nan::SetPrototypeMethod(ctor, "setPad", SetPad);
 	Nan::SetPrototypeMethod(ctor, "pollBus", PollBus);
 			
 	Nan::SetAccessor(proto, Nan::New("auto-flush-bus").ToLocalChecked(), GetAutoFlushBus, SetAutoFlushBus);
@@ -126,6 +127,28 @@ NAN_METHOD(Pipeline::FindChild) {
 		info.GetReturnValue().Set(GObjectWrap::NewInstance(info, o));
 	else
 		info.GetReturnValue().Set(Nan::Undefined());
+}
+
+void Pipeline::setPad(GObject *elem, const char *attribute, const char *padName) {
+	GstPad *pad = gst_element_get_static_pad(GST_ELEMENT(elem), padName);
+	if (!pad) {
+		return;
+	}
+	g_object_set(elem, attribute, pad, NULL);
+}
+
+
+NAN_METHOD(Pipeline::SetPad) {
+	Pipeline* obj = Nan::ObjectWrap::Unwrap<Pipeline>(info.This());
+	Nan::Utf8String name(info[0]);
+	GObject *o = obj->findChild(*name);
+	if(!o) {
+		return;
+	}
+
+	Nan::Utf8String attribute(info[1]);
+	Nan::Utf8String padName(info[2]);
+	obj->setPad(o, *attribute, *padName);
 }
 
 class BusRequest : public Nan::AsyncResource {

--- a/Pipeline.h
+++ b/Pipeline.h
@@ -19,6 +19,8 @@ class Pipeline : public Nan::ObjectWrap {
 		GObject *findChild( const char *name );
 		Local<Value> pollBus();
 		
+		void setPad( GObject* elem, const char *attribute, const char *padName );
+		
 	private:
 		Pipeline(const char *launch);
 		Pipeline(GstPipeline *pipeline);
@@ -35,6 +37,7 @@ class Pipeline : public Nan::ObjectWrap {
 		static NAN_METHOD(SendEOS);
 		static NAN_METHOD(ForceKeyUnit);
 		static NAN_METHOD(FindChild);
+		static NAN_METHOD(SetPad);
 
 		static void _doPollBus( uv_work_t *req );
 		static void _polledBus( uv_work_t *req, int );


### PR DESCRIPTION
Motivation of this PR is to use [input-selector](https://gstreamer.freedesktop.org/data/doc/gstreamer/head/gstreamer-plugins/html/gstreamer-plugins-input-selector.html), and to set "active-pad".

It works like below.

```js
const gstreamer = require('gstreamer-superficial');

const pipeline = new gstreamer.Pipeline([
    'input-selector name=sel',
    '! autovideosink',
    'videotestsrc pattern=0',
    '! sel.sink_0',
    'videotestsrc pattern=1',
    '! sel.sink_1'
].join(' '));
pipeline.play();

let t = 0;
setInterval( function() {
    t++;
    console.log('t: %d', t)

    if (t % 2 === 0) {
        pipeline.setPad('sel', 'active-pad', 'sink_0')
    }
    else {
        pipeline.setPad('sel', 'active-pad', 'sink_1')
    }
    
}, 1000 );
```