### PR TITLE
Fix CMakelists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,11 @@
 cmake_minimum_required(VERSION 2.8.4)
 project(gstreamer-superficial)
 
-set(NODE_INCLUDE_DIRS /usr/include/node)
+if (NOT DEFINED ENV{NODE_INCLUDE_DIRS})
+    set(NODE_INCLUDE_DIRS /usr/include/node)
+else()
+    set(NODE_INCLUDE_DIRS $ENV{NODE_INCLUDE_DIRS})
+endif()
 
 find_package(PkgConfig)
 pkg_check_modules(gstreamer-1.0 gstreamer-app-1.0 gstreamer-video-1.0)

--- a/README.md
+++ b/README.md
@@ -88,6 +88,6 @@ in package.json.
 
 ## Requisites
 
-* `libgstreamer-plugins-base1.0-dev` with APT
-* `libgstreamer1.0-dev` with APT
-* `nan`: `npm -i nan --save`
+* `libgstreamer-plugins-base1.0-dev`
+* `libgstreamer1.0-dev`
+* `nan`

--- a/package.json
+++ b/package.json
@@ -50,6 +50,10 @@
     {
       "name": "maruware",
       "url": "https://github.com/maruware"
+    },
+    {
+      "name": "Luis G. Leon-Vega",
+      "url": "https://github.com/lleon95"
     }
   ],
   "dependencies": {


### PR DESCRIPTION
This pull request:

* Adds `NODE_INCLUDE_DIRS` to the CMakelist.txt to make the node inclusion parametric, since it is hard-coded.
* Dynamises the GStreamer library search
* Adds dependences to the Readme.md