### PR TITLE
Use environment variables to locate Windows GStreamer includes

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -36,16 +36,17 @@
 		}],
 		["OS=='win'", {
 			"include_dirs": [
-				"X:/gstreamer-sdk/1.0/x86_64/include/gstreamer-1.0",
-				"X:/gstreamer-sdk/1.0/x86_64/include/glib-2.0",
-				"X:/gstreamer-sdk/1.0/x86_64/include/libxml2"
+				"<!(echo %GSTREAMER_1_0_ROOT_X86_64%)include\gstreamer-1.0",
+				"<!(echo %GSTREAMER_1_0_ROOT_X86_64%)lib\glib-2.0\include",
+				"<!(echo %GSTREAMER_1_0_ROOT_X86_64%)include\glib-2.0",
+				"<!(echo %GSTREAMER_1_0_ROOT_X86_64%)include\libxml2"
 			],
 			"libraries": [
-				"X:/gstreamer-sdk/1.0/x86_64/lib/gstreamer-1.0.lib",
-				"X:/gstreamer-sdk/1.0/x86_64/lib/gstapp-1.0.lib",
-				"X:/gstreamer-sdk/1.0/x86_64/lib/gstvideo-1.0.lib",
-				"X:/gstreamer-sdk/1.0/x86_64/lib/gobject-2.0.lib",
-				"X:/gstreamer-sdk/1.0/x86_64/lib/glib-2.0.lib"
+				"<!(echo %GSTREAMER_1_0_ROOT_X86_64%)lib\gstreamer-1.0.lib",
+				"<!(echo %GSTREAMER_1_0_ROOT_X86_64%)lib\gstapp-1.0.lib",
+				"<!(echo %GSTREAMER_1_0_ROOT_X86_64%)lib\gstvideo-1.0.lib",
+				"<!(echo %GSTREAMER_1_0_ROOT_X86_64%)lib\gobject-2.0.lib",
+				"<!(echo %GSTREAMER_1_0_ROOT_X86_64%)lib\glib-2.0.lib"
 			]
 		}]
 	  ]


### PR DESCRIPTION
I needed to make a few changes to `binding.gyp` to build on Windows.

As suggested by https://github.com/dturing/node-gstreamer-superficial/commit/2cf84d7b13133deb452b003cf256f2b0eba41282#r21118956, here is a modification to `binding.gyp` to use the environment variables set by the official GStreamer dev distribution on Windows. While this is still overly specific to the "X86_64" arch, it's an incremental improvement, allowing builds regardless of which drive / base directory the header files are installed in.