### PR TITLE
binding.gyp: fix typo, app -> video

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -14,7 +14,7 @@
 			"include_dirs": [
 				'<!@(pkg-config gstreamer-1.0 --cflags-only-I | sed s/-I//g)',
 				'<!@(pkg-config gstreamer-app-1.0 --cflags-only-I | sed s/-I//g)',
-				'<!@(pkg-config gstreamer-app-1.0 --cflags-only-I | sed s/-I//g)'
+				'<!@(pkg-config gstreamer-video-1.0 --cflags-only-I | sed s/-I//g)'
 			],
 			"libraries": [
 				'<!@(pkg-config gstreamer-1.0 --libs)',
@@ -26,7 +26,7 @@
 			"include_dirs": [
 				'<!@(pkg-config gstreamer-1.0 --cflags-only-I | sed s/-I//g)',
 				'<!@(pkg-config gstreamer-app-1.0 --cflags-only-I | sed s/-I//g)',
-				'<!@(pkg-config gstreamer-app-1.0 --cflags-only-I | sed s/-I//g)'
+				'<!@(pkg-config gstreamer-video-1.0 --cflags-only-I | sed s/-I//g)'
 			],
 			"libraries": [
 				'<!@(pkg-config gstreamer-1.0 --libs)',


### PR DESCRIPTION
Most things seem to work regardless of this typo, but sure does look like a typo nonetheless.