### PR TITLE
Ensure gstreamer objects are unreferenced after use

### DIFF
--- a/GObjectWrap.cpp
+++ b/GObjectWrap.cpp
@@ -19,6 +19,13 @@ void GObjectWrap::Init() {
 	constructor.Reset(Nan::GetFunction(ctor).ToLocalChecked());
 }
 
+GObjectWrap::~GObjectWrap() {
+    if (obj) {
+        g_object_unref(G_OBJECT(obj));
+        obj = nullptr;
+    }
+}
+
 NAN_METHOD(GObjectWrap::New) {
 	GObjectWrap* obj = new GObjectWrap();
 	obj->Wrap(info.This());

--- a/GObjectWrap.h
+++ b/GObjectWrap.h
@@ -19,7 +19,7 @@ class GObjectWrap : public Nan::ObjectWrap {
 
 	private:
 		GObjectWrap() {}
-		~GObjectWrap() {}
+		~GObjectWrap();
 
 		GObject *obj;
 

--- a/Pipeline.cpp
+++ b/Pipeline.cpp
@@ -27,6 +27,13 @@ Pipeline::Pipeline(GstPipeline* pipeline) {
 	this->pipeline = pipeline;
 }
 
+Pipeline::~Pipeline() {
+    if (pipeline) {
+        gst_object_unref(GST_OBJECT(pipeline));
+        pipeline = nullptr;
+    }
+}
+
 void Pipeline::Init(Nan::ADDON_REGISTER_FUNCTION_ARGS_TYPE exports) {
 	Nan::HandleScope scope;
 

--- a/Pipeline.h
+++ b/Pipeline.h
@@ -28,7 +28,7 @@ class Pipeline : public Nan::ObjectWrap {
 	private:
 		Pipeline(const char *launch);
 		Pipeline(GstPipeline *pipeline);
-		~Pipeline() {}
+		~Pipeline();
 
 		static Nan::Persistent<Function> constructor;
 


### PR DESCRIPTION
We need this to keep memory usage under control when creating and destroying many temporary pipelines.

Thanks!